### PR TITLE
escape backslashes

### DIFF
--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -36,6 +36,7 @@ class SplunkBackend(TextQueryBackend):
     escape_char : ClassVar[str] = "\\"
     wildcard_multi : ClassVar[str] = "*"
     wildcard_single : ClassVar[str] = "*"
+    add_escaped : ClassVar[str] = "\\"
 
     re_expression : ClassVar[str] = "{regex}"
     re_escape_char : ClassVar[str] = "\\"


### PR DESCRIPTION
at the moment the backend is not escaping backslashes.
e.g. 
```bash
sigma convert -t splunk ./rules/windows/process_creation/proc_creation_win_office_shell.yml
```
results in
```
ParentImage="*\WINWORD.EXE" OR ParentImage="*\EXCEL.EXE" OR ParentImage="*\POWERPNT.exe" OR ParentImage="*\MSPUB.exe" OR ParentImage="*\VISIO.exe" OR ParentImage="*\MSACCESS.EXE" OR ParentImage="*\EQNEDT32.EXE") (Image="*\cmd.exe" OR Image="*\powershell.exe" OR Image="*\wscript.exe" OR Image="*\cscript.exe" OR Image="*\sh.exe" OR Image="*\bash.exe" OR Image="*\scrcons.exe" OR Image="*\schtasks.exe" OR Image="*\regsvr32.exe" OR Image="*\hh.exe" OR Image="*\wmic.exe" OR Image="*\mshta.exe" OR Image="*\rundll32.exe" OR Image="*\msiexec.exe" OR Image="*\forfiles.exe" OR Image="*\scriptrunner.exe" OR Image="*\mftrace.exe" OR Image="*\AppVLP.exe" OR Image="*\svchost.exe" OR Image="*\msbuild.exe")
```

with the change in this PR the new query is:
```
(ParentImage="*\\WINWORD.EXE" OR ParentImage="*\\EXCEL.EXE" OR ParentImage="*\\POWERPNT.exe" OR ParentImage="*\\MSPUB.exe" OR ParentImage="*\\VISIO.exe" OR ParentImage="*\\MSACCESS.EXE" OR ParentImage="*\\EQNEDT32.EXE") (Image="*\\cmd.exe" OR Image="*\\powershell.exe" OR Image="*\\wscript.exe" OR Image="*\\cscript.exe" OR Image="*\\sh.exe" OR Image="*\\bash.exe" OR Image="*\\scrcons.exe" OR Image="*\\schtasks.exe" OR Image="*\\regsvr32.exe" OR Image="*\\hh.exe" OR Image="*\\wmic.exe" OR Image="*\\mshta.exe" OR Image="*\\rundll32.exe" OR Image="*\\msiexec.exe" OR Image="*\\forfiles.exe" OR Image="*\\scriptrunner.exe" OR Image="*\\mftrace.exe" OR Image="*\\AppVLP.exe" OR Image="*\\svchost.exe" OR Image="*\\msbuild.exe")
```