### PR TITLE
Added initiliazation and condition to avoid UbuoundLocalError

### DIFF
--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -134,7 +134,7 @@ dispatch.latest_time = {self.max_time}
             """.replace("\n", " ")
             return data_model_query
         else:
-            return ""
+            raise SigmaFeatureNotSupportedByBackendError("No data model matches rule log source")
 
     def finalize_output_data_model(self, queries: List[str]) -> List[str]:
         return queries

--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -128,10 +128,10 @@ dispatch.latest_time = {self.max_time}
 
         if data_model is not None and data_set is not None and cim_fields is not None:
             data_model_query = f"""| tstats summariesonly=false allow_old_summaries=true fillnull_value="null" count min(_time) as firstTime max(_time) as lastTime from datamodel={data_model}.{data_set} where {query} by {cim_fields}
-            | `drop_dm_object_name({data_set})`
-            | convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(firstTime)
-            | convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(lastTime)
-            """.replace("\n", " ")
+| `drop_dm_object_name({data_set})`
+| convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(firstTime)
+| convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(lastTime)
+""".replace("\n", " ")
             return data_model_query
         else:
             raise SigmaFeatureNotSupportedByBackendError("No data model matches rule log source")

--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -103,6 +103,9 @@ dispatch.latest_time = {self.max_time}
 """ + "\n".join(queries)
 
     def finalize_query_data_model(self, rule: SigmaRule, query: str, index: int, state: ConversionState) -> str:
+        data_model = None
+        data_set = None
+        cim_fields = None
         if rule.logsource.product and rule.logsource.category:
             if rule.logsource.product == "windows":
                 if rule.logsource.category == "process_creation":
@@ -123,12 +126,15 @@ dispatch.latest_time = {self.max_time}
                     data_set = 'Processes'
                     cim_fields = " ".join(splunk_sysmon_process_creation_cim_mapping.values())
 
-        data_model_query = f"""| tstats summariesonly=false allow_old_summaries=true fillnull_value="null" count min(_time) as firstTime max(_time) as lastTime from datamodel={data_model}.{data_set} where {query} by {cim_fields}
-| `drop_dm_object_name({data_set})`
-| convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(firstTime)
-| convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(lastTime)
-""".replace("\n", " ")
-        return data_model_query
+        if data_model is not None and data_set is not None and cim_fields is not None:
+            data_model_query = f"""| tstats summariesonly=false allow_old_summaries=true fillnull_value="null" count min(_time) as firstTime max(_time) as lastTime from datamodel={data_model}.{data_set} where {query} by {cim_fields}
+            | `drop_dm_object_name({data_set})`
+            | convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(firstTime)
+            | convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(lastTime)
+            """.replace("\n", " ")
+            return data_model_query
+        else:
+            return ""
 
     def finalize_output_data_model(self, queries: List[str]) -> List[str]:
         return queries

--- a/tests/test_backend_splunk.py
+++ b/tests/test_backend_splunk.py
@@ -332,3 +332,19 @@ Processes.parent_process_path Processes.parent_process_guid Processes.parent_pro
 | convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(firstTime)
 | convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(lastTime)
 """.replace("\n", " ")]
+
+def test_splunk_data_model_no_matching_data_model():
+    splunk_backend = SplunkBackend()
+    rule = """
+title: Test
+status: test
+logsource:
+    product: windows
+    service: security
+detection:
+    sel:
+        CommandLine: test
+    condition: sel
+    """
+    with pytest.raises(SigmaFeatureNotSupportedByBackendError, match="data model matches"):
+        splunk_backend.convert(SigmaCollection.from_yaml(rule), "data_model")


### PR DESCRIPTION
When a query is given to be converted and the query does not match one of logsource categories, some variables are not initialized (data_model, data_set and cim_fields) and when trying to output the query string with data_model, there is a python exception UnboundLocalError.
Added initilization of those variables and a condition to check. If any of the variable is not initialized, return an empty string.