### PR TITLE
Include alert descriptions in savedsearch output

### DIFF
--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -95,9 +95,11 @@ class SplunkBackend(TextQueryBackend):
 
     def finalize_query_savedsearches(self, rule: SigmaRule, query: str, index: int, state: ConversionState) -> str:
         clean_title = rule.title.translate({ord(c): None for c in "[]"})      # remove brackets from title
+        escaped_description = "\\\n".join(rule.description.strip().split("\n")) if rule.description else ""      # support multi-line descriptions
         escaped_query = " \\\n".join(query.split("\n"))      # escape line ends for multiline queries
         return f"""
 [{clean_title}]
+description = {escaped_description}
 search = {escaped_query}"""
 
     def finalize_output_savedsearches(self, queries: List[str]) -> str:

--- a/tests/test_backend_splunk.py
+++ b/tests/test_backend_splunk.py
@@ -220,6 +220,9 @@ def test_splunk_cidr_or(splunk_backend : SplunkBackend):
 def test_splunk_savedsearch_output(splunk_backend : SplunkBackend):
     rules = """
 title: Test 1
+description: |
+  this is a description
+  across two lines
 status: test
 logsource:
     category: test_category
@@ -248,10 +251,13 @@ dispatch.earliest_time = -30d
 dispatch.latest_time = now
 
 [Test 1]
+description = this is a description\\
+across two lines
 search = fieldB="foo" fieldC="bar" \\
 | regex fieldA="foo.*bar"
 
 [Test 2]
+description = 
 search = fieldA="foo" fieldB="bar\""""
 
 def test_splunk_data_model_process_creation():


### PR DESCRIPTION
If the sigma rule contains a description, include it in the generated savedsearch.conf output, so it is visible in the UI when running searches and viewing search results.

If there is no description available, leave as an empty string (per the [spec](https://docs.splunk.com/Documentation/Splunk/9.0.1/admin/savedsearchesconf#UI-specific_settings)).