### PR TITLE
Use rule fields to generate 'table' search output

### DIFF
--- a/tests/test_backend_splunk.py
+++ b/tests/test_backend_splunk.py
@@ -227,6 +227,8 @@ status: test
 logsource:
     category: test_category
     product: test_product
+fields:
+    - fieldA
 detection:
     sel:
         fieldA|re: foo.*bar
@@ -239,6 +241,9 @@ status: test
 logsource:
     category: test_category
     product: test_product
+fields:
+    - fieldA
+    - fieldB
 detection:
     sel:
         fieldA: foo
@@ -254,11 +259,13 @@ dispatch.latest_time = now
 description = this is a description\\
 across two lines
 search = fieldB="foo" fieldC="bar" \\
-| regex fieldA="foo.*bar"
+| regex fieldA="foo.*bar" \\
+| table fieldA
 
 [Test 2]
 description = 
-search = fieldA="foo" fieldB="bar\""""
+search = fieldA="foo" fieldB="bar" \\
+| table fieldA,fieldB"""
 
 def test_splunk_data_model_process_creation():
     splunk_backend = SplunkBackend(processing_pipeline=splunk_cim_data_model())

--- a/tests/test_backend_splunk.py
+++ b/tests/test_backend_splunk.py
@@ -217,6 +217,23 @@ def test_splunk_cidr_or(splunk_backend : SplunkBackend):
             """)
         )
 
+def test_splunk_fields_output(splunk_backend : SplunkBackend):
+    rule = SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            fields:
+                - fieldA
+            detection:
+                sel:
+                    fieldA: valueA
+                condition: sel
+        """)
+
+    assert splunk_backend.convert(rule) == ['fieldA="valueA" | table fieldA']
+
 def test_splunk_savedsearch_output(splunk_backend : SplunkBackend):
     rules = """
 title: Test 1


### PR DESCRIPTION
Per #12 I took a look at implementing [this](https://github.com/SigmaHQ/sigma/blob/8e12115516ea88c2ea2c72e33e5af0cc5d8f1f93/tools/sigma/backends/splunk.py#L80-L90). Field names in `fields` were already remapped during pipeline processing, so no extra steps were necessary.