### PR TITLE
Custom savedsearch.conf settings

### DIFF
--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -8,7 +8,7 @@ from sigma.types import SigmaCompareExpression
 from sigma.exceptions import SigmaFeatureNotSupportedByBackendError
 from sigma.pipelines.splunk.splunk import splunk_sysmon_process_creation_cim_mapping, splunk_windows_registry_cim_mapping, splunk_windows_file_event_cim_mapping
 import sigma
-from typing import ClassVar, Dict, List, Optional, Pattern, Tuple
+from typing import Callable, ClassVar, Dict, List, Optional, Pattern, Tuple
 
 class SplunkDeferredRegularExpression(DeferredTextQueryExpression):
     template = 'regex {field}{op}"{value}"'
@@ -76,10 +76,11 @@ class SplunkBackend(TextQueryBackend):
     deferred_separator : ClassVar[str] = "\n| "
     deferred_only_query : ClassVar[str] = "*"
 
-    def __init__(self, processing_pipeline: Optional["sigma.processing.pipeline.ProcessingPipeline"] = None, collect_errors: bool = False, min_time : str = "-30d", max_time : str = "now", **kwargs):
+    def __init__(self, processing_pipeline: Optional["sigma.processing.pipeline.ProcessingPipeline"] = None, collect_errors: bool = False, min_time : str = "-30d", max_time : str = "now", gen_settings : Callable[[SigmaRule], Dict[str, str]] = lambda x: {}, output_settings : Dict = {}, **kwargs):
         super().__init__(processing_pipeline, collect_errors, **kwargs)
-        self.min_time = min_time or "-30d"
-        self.max_time = max_time or "now"
+        self.gen_settings = gen_settings
+        self.output_settings = {"dispatch.earliest_time": min_time, "dispatch.latest_time": max_time}
+        self.output_settings.update(output_settings)
 
     def convert_condition_field_eq_val_re(self, cond : ConditionFieldEqualsValueExpression, state : "sigma.conversion.state.ConversionState") -> SplunkDeferredRegularExpression:
         """Defer regular expression matching to pipelined regex command after main search expression."""
@@ -94,25 +95,26 @@ class SplunkBackend(TextQueryBackend):
         return SplunkDeferredCIDRExpression(state, cond.field, super().convert_condition_field_eq_val_cidr(cond, state)).postprocess(None, cond)
 
     def finalize_query_default(self, rule : SigmaRule, query : str, index : int, state : ConversionState) -> str:
-        table_fields = (" | table " + ",".join(rule.fields)) if rule.fields else ""
+        table_fields = " | table " + ",".join(rule.fields) if rule.fields else ""
         return query + table_fields
 
     def finalize_query_savedsearches(self, rule: SigmaRule, query: str, index: int, state: ConversionState) -> str:
         clean_title = rule.title.translate({ord(c): None for c in "[]"})      # remove brackets from title
-        escaped_description = "\\\n".join(rule.description.strip().split("\n")) if rule.description else ""      # support multi-line descriptions
-        escaped_query = " \\\n".join(query.split("\n"))      # escape line ends for multiline queries
-        table_fields = (" \\\n| table " + ",".join(rule.fields)) if rule.fields else ""
-        return f"""
-[{clean_title}]
-description = {escaped_description}
-search = {escaped_query}{table_fields}"""
+        query_settings = self.gen_settings(rule)
+        query_settings["description"] = rule.description.strip() if rule.description else ""
+        query_settings["search"] = query + ("\n| table " + ",".join(rule.fields) if rule.fields else "")
+
+        output = f"\n[{clean_title}]"
+        for k, v in query_settings.items():
+            output += f"\n{k} = " + " \\\n".join(v.split("\n"))  # cannot use \ in f-strings
+        return output
 
     def finalize_output_savedsearches(self, queries: List[str]) -> str:
-        return f"""
-[default]
-dispatch.earliest_time = {self.min_time}
-dispatch.latest_time = {self.max_time}
-""" + "\n".join(queries)
+        output = f"\n[default]\n"
+        for k, v in self.output_settings.items():
+            output += f"{k} = {v}\n"
+        output += "\n".join(queries)
+        return output
 
     def finalize_query_data_model(self, rule: SigmaRule, query: str, index: int, state: ConversionState) -> str:
         data_model = None

--- a/tests/test_backend_splunk.py
+++ b/tests/test_backend_splunk.py
@@ -10,7 +10,7 @@ def splunk_backend():
 
 @pytest.fixture
 def splunk_custom_backend():
-    return SplunkBackend(gen_settings = lambda x: {"custom.query.key": x.title}, output_settings = {"custom.key": "customvalue"})
+    return SplunkBackend(query_settings = lambda x: {"custom.query.key": x.title}, output_settings = {"custom.key": "customvalue"})
 
 def test_splunk_and_expression(splunk_backend : SplunkBackend):
     rule = SigmaCollection.from_yaml("""

--- a/tests/test_backend_splunk.py
+++ b/tests/test_backend_splunk.py
@@ -8,6 +8,10 @@ from sigma.pipelines.splunk import splunk_cim_data_model
 def splunk_backend():
     return SplunkBackend()
 
+@pytest.fixture
+def splunk_custom_backend():
+    return SplunkBackend(gen_settings = lambda x: {"custom.query.key": x.title}, output_settings = {"custom.key": "customvalue"})
+
 def test_splunk_and_expression(splunk_backend : SplunkBackend):
     rule = SigmaCollection.from_yaml("""
             title: Test
@@ -273,13 +277,66 @@ dispatch.earliest_time = -30d
 dispatch.latest_time = now
 
 [Test 1]
-description = this is a description\\
+description = this is a description \\
 across two lines
 search = fieldB="foo" fieldC="bar" \\
 | regex fieldA="foo.*bar" \\
 | table fieldA
 
 [Test 2]
+description = 
+search = fieldA="foo" fieldB="bar" \\
+| table fieldA,fieldB"""
+
+def test_splunk_savedsearch_output_custom(splunk_custom_backend : SplunkBackend):
+    rules = """
+title: Test 1
+description: |
+  this is a description
+  across two lines
+status: test
+logsource:
+    category: test_category
+    product: test_product
+fields:
+    - fieldA
+detection:
+    sel:
+        fieldA|re: foo.*bar
+        fieldB: foo
+        fieldC: bar
+    condition: sel
+---
+title: Test 2
+status: test
+logsource:
+    category: test_category
+    product: test_product
+fields:
+    - fieldA
+    - fieldB
+detection:
+    sel:
+        fieldA: foo
+        fieldB: bar
+    condition: sel
+    """
+    assert splunk_custom_backend.convert(SigmaCollection.from_yaml(rules), "savedsearches") == """
+[default]
+dispatch.earliest_time = -30d
+dispatch.latest_time = now
+custom.key = customvalue
+
+[Test 1]
+custom.query.key = Test 1
+description = this is a description \\
+across two lines
+search = fieldB="foo" fieldC="bar" \\
+| regex fieldA="foo.*bar" \\
+| table fieldA
+
+[Test 2]
+custom.query.key = Test 2
 description = 
 search = fieldA="foo" fieldB="bar" \\
 | table fieldA,fieldB"""


### PR DESCRIPTION
Add support for arbitrary [savedsearch.conf settings](https://docs.splunk.com/Documentation/Splunk/9.0.1/admin/savedsearchesconf), both per-rule and overall. A use-case for this might be for configuring Splunk alert actions (e.g. send to email / webhook) or search frequency (as in #11). Adds two new args to the backend constructor:
- `query_settings` -- pass in a function which takes a `SigmaRule` object as an arg and returns a dict of settings that should apply to that specific rule. This needs to be dynamic as setting values could depend on the rule description/severity/etc.
- `output_settings` -- pass in a dict of settings that should apply to all rules/alerts

A (simplified) example use-case of dynamically setting the alert's email subject and search frequency:
```py
def gen_settings(rule):
    settings = {
        "action.email.subject": f"[{rule.level} alert]: {rule.title}",
    }
    if rule.level in ["high", "critical"]:
        settings["dispatch.earliest_time"] = "-10m"
        settings["cron_schedule"] = "*/10 * * * *"
    return settings

backend = SplunkBackend(
    processing_pipeline=pipelines,
    min_time="-45m",
    query_settings=gen_settings,
    output_settings={"action.email.to": "alerts@example.com", "cron_schedule": "*/45 * * * *"},
)
```
```ini
[default]
dispatch.earliest_time = -45m
dispatch.latest_time = now
action.email.to = alerts@example.com
cron_schedule = */45 * * * *

[Rule 1]
action.email.subject = [medium alert]: Rule 1
search = abc

[Rule 2]
action.email.subject = [critical alert]: Rule 2
dispatch.earliest_time = -10m
cron_schedule = */10 * * * *
search = xyz
```

I didn't see any formatting/linter configs, so I attempted to mimic existing style (not sure what you want to do about line 79... thoughts on applying something like [black](https://black.readthedocs.io/en/stable/) to this library?).

Welcome any thoughts/comments about this PR!