### PR TITLE
Original file name addition

### DIFF
--- a/sigma/pipelines/splunk/splunk.py
+++ b/sigma/pipelines/splunk/splunk.py
@@ -23,6 +23,7 @@ splunk_sysmon_process_creation_cim_mapping = {
     "CurrentDirectory": "Processes.process_current_directory",
     "Image": "Processes.process_path",
     "IntegrityLevel": "Processes.process_integrity_level",
+    "OriginalFileName": "Processes.original_file_name",
     "ParentCommandLine": "Processes.parent_process",
     "ParentImage": "Processes.parent_process_path",
     "ParentProcessGuid": "Processes.parent_process_guid",

--- a/tests/test_splunk_pipelines.py
+++ b/tests/test_splunk_pipelines.py
@@ -100,7 +100,7 @@ def test_splunk_process_creation_dm():
                     User: test
                 condition: sel
         """)
-    ) == [f"Processes.process=\"test\" Processes.process_current_directory=\"test\" Processes.process_path=\"test\" Processes.process_integrity_level=\"test\" Processes.parent_process=\"test\" Processes.parent_process_path=\"test\" Processes.parent_process_guid=\"test\" Processes.parent_process_id=\"test\" Processes.process_guid=\"test\" Processes.process_id=\"test\" Processes.user=\"test\""]
+    ) == [f"Processes.process=\"test\" Processes.process_current_directory=\"test\" Processes.process_path=\"test\" Processes.process_integrity_level=\"test\" Processes.original_file_name=\"test\" Processes.parent_process=\"test\" Processes.parent_process_path=\"test\" Processes.parent_process_guid=\"test\" Processes.parent_process_id=\"test\" Processes.process_guid=\"test\" Processes.process_id=\"test\" Processes.user=\"test\""]
 
 def test_splunk_process_creation_dm_unsupported_fields():
     with pytest.raises(SigmaTransformationError):

--- a/tests/test_splunk_pipelines.py
+++ b/tests/test_splunk_pipelines.py
@@ -90,6 +90,7 @@ def test_splunk_process_creation_dm():
                     CurrentDirectory: test
                     Image: test
                     IntegrityLevel: test
+                    OriginalFileName: test
                     ParentCommandLine: test
                     ParentImage: test
                     ParentProcessGuid: test


### PR DESCRIPTION
Added OriginalFileName (Sysmon EID 1) mapping for Splunk CIM compliance. Also added OriginalFileName to the process creation datamodel test.