### PR TITLE
Add support for Web.Proxy Splunk data model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysigma-backend-splunk"
-version = "1.1.0"
+version = "1.1.1"
 description = "pySigma Splunk backend"
 readme = "README.md"
 authors = ["Thomas Patzke <thomas@patzke.org>"]

--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -16,6 +16,7 @@ from sigma.pipelines.splunk.splunk import (
     splunk_sysmon_process_creation_cim_mapping,
     splunk_windows_registry_cim_mapping,
     splunk_windows_file_event_cim_mapping,
+    splunk_web_proxy_cim_mapping,
 )
 import sigma
 from typing import Callable, ClassVar, Dict, List, Optional, Pattern, Tuple
@@ -280,6 +281,13 @@ class SplunkBackend(TextQueryBackend):
                     cim_fields = " ".join(
                         splunk_sysmon_process_creation_cim_mapping.values()
                     )
+                    
+        elif rule.logsource.category == "proxy":
+            data_model = "Web"
+            data_set = "Proxy"
+            cim_fields = " ".join(
+                splunk_web_proxy_cim_mapping.values()
+            )
 
         try:
             data_model_set = state.processing_state["data_model_set"]


### PR DESCRIPTION
Opening a PR to add support for Web Proxy datamodel.

It can be used for sigma rules using the logsource category "proxy".

Change the package version to 1.1.1
Change the backends to support Web Proxy CIM
Change the pipelines to support Web Proxy CIM