### PR TITLE
Fixing field null expression

### DIFF
--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -135,7 +135,7 @@ class SplunkBackend(TextQueryBackend):
         SigmaCompareExpression.CompareOperators.GTE: ">=",
     }
 
-    field_null_expression: ClassVar[str] = "{field}!=*"
+    field_null_expression: ClassVar[str] = "NOT {field}=*"
 
     convert_or_as_in: ClassVar[bool] = True
     convert_and_as_in: ClassVar[bool] = False


### PR DESCRIPTION
The [splunk docs](https://docs.splunk.com/Documentation/Splunk/9.3.2/Search/Usefieldstoretrieveevents) mention that `field!=*` will "never return any events", and that `NOT field=*` return events where field is null/undefined. After some tests I can confirm that the `NOT field=*` is returning events where the field is absent (which is the meaning of `field: null` in sigma, a not existing or empty field).
This [splunk discussion](https://community.splunk.com/t5/Splunk-Search/How-can-I-search-for-a-missing-field/m-p/9599) confirmed this behavior too.
