### PR TITLE
Improving regex oring

### DIFF
--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -271,6 +271,21 @@ class SplunkBackend(TextQueryBackend):
             state, cond.field, super().convert_condition_field_eq_val_re(cond, state)
         ).postprocess(None, cond)
 
+    def convert_condition_field_eq_field(
+        self,
+        cond: ConditionFieldEqualsValueExpression,
+        state: "sigma.conversion.state.ConversionState",
+    ) -> SplunkDeferredFieldRefExpression:
+        """Defer FieldRef matching to pipelined with `where` command after main search expression."""
+        if cond.parent_condition_chain_contains(ConditionOR):
+            raise SigmaFeatureNotSupportedByBackendError(
+                "ORing FieldRef matching is not yet supported by Splunk backend",
+                source=cond.source,
+            )
+        return SplunkDeferredFieldRefExpression(
+            state, cond.field, super().convert_condition_field_eq_field(cond, state)
+        ).postprocess(None, cond)
+
     def finalize_query(
         self,
         rule: SigmaRule,

--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -86,6 +86,15 @@ class SplunkDeferredORRegularExpression(DeferredTextQueryExpression):
         cls.field_counts = {}
 
 
+class SplunkDeferredFieldRefExpression(DeferredTextQueryExpression):
+    template = "where {op}'{field}'='{value}'"
+    operators = {
+        True: "NOT ",
+        False: "",
+    }
+    default_field = "_raw"
+
+
 class SplunkBackend(TextQueryBackend):
     """Splunk SPL backend."""
 
@@ -138,6 +147,7 @@ class SplunkBackend(TextQueryBackend):
         SigmaCompareExpression.CompareOperators.GTE: ">=",
     }
 
+    field_equals_field_expression: ClassVar[str] = "{field2}"
     field_null_expression: ClassVar[str] = "NOT {field}=*"
 
     convert_or_as_in: ClassVar[bool] = True

--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -119,6 +119,7 @@ class SplunkBackend(TextQueryBackend):
     )
     group_expression: ClassVar[str] = "({expr})"
 
+    bool_values = {True: "true", False: "false"}
     or_token: ClassVar[str] = "OR"
     and_token: ClassVar[str] = " "
     not_token: ClassVar[str] = "NOT"

--- a/tests/test_backend_splunk.py
+++ b/tests/test_backend_splunk.py
@@ -328,6 +328,52 @@ def test_splunk_cidr_or(splunk_backend: SplunkBackend):
     )
 
 
+def test_splunk_fieldref_query(splunk_backend: SplunkBackend):
+    assert (
+        splunk_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    fieldA|fieldref: fieldD
+                    fieldB: foo
+                    fieldC: bar
+                condition: sel
+        """
+            )
+        )
+        == ["fieldB=\"foo\" fieldC=\"bar\"\n| where 'fieldA'='fieldD'"]
+    )
+
+
+def test_splunk_fieldref_or(splunk_backend: SplunkBackend):
+    with pytest.raises(SigmaFeatureNotSupportedByBackendError, match="ORing FieldRef"):
+        splunk_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+                title: Test
+                status: test
+                logsource:
+                    category: test_category
+                    product: test_product
+                detection:
+                    sel:
+                        fieldA|fieldref:
+                            - fieldD
+                            - fieldE
+                        fieldB: foo
+                        fieldC: bar
+                    condition: sel
+            """
+            )
+        )
+
+
 def test_splunk_fields_output(splunk_backend: SplunkBackend):
     rule = SigmaCollection.from_yaml(
         """

--- a/tests/test_backend_splunk.py
+++ b/tests/test_backend_splunk.py
@@ -302,15 +302,14 @@ def test_splunk_cidr_query(splunk_backend: SplunkBackend):
         """
             )
         )
-        == ['fieldB="foo" fieldC="bar"\n| where cidrmatch("192.168.0.0/16", fieldA)']
+        == ['fieldA="192.168.0.0/16" fieldB="foo" fieldC="bar"']
     )
 
 
 def test_splunk_cidr_or(splunk_backend: SplunkBackend):
-    with pytest.raises(SigmaFeatureNotSupportedByBackendError, match="ORing CIDR"):
-        splunk_backend.convert(
-            SigmaCollection.from_yaml(
-                """
+    assert splunk_backend.convert(
+        SigmaCollection.from_yaml(
+            """
                 title: Test
                 status: test
                 logsource:
@@ -325,8 +324,8 @@ def test_splunk_cidr_or(splunk_backend: SplunkBackend):
                         fieldC: bar
                     condition: sel
             """
-            )
         )
+    )
 
 
 def test_splunk_fields_output(splunk_backend: SplunkBackend):

--- a/tests/test_backend_splunk.py
+++ b/tests/test_backend_splunk.py
@@ -307,9 +307,10 @@ def test_splunk_cidr_query(splunk_backend: SplunkBackend):
 
 
 def test_splunk_cidr_or(splunk_backend: SplunkBackend):
-    assert splunk_backend.convert(
-        SigmaCollection.from_yaml(
-            """
+    assert (
+        splunk_backend.convert(
+            SigmaCollection.from_yaml(
+                """
                 title: Test
                 status: test
                 logsource:
@@ -324,7 +325,9 @@ def test_splunk_cidr_or(splunk_backend: SplunkBackend):
                         fieldC: bar
                     condition: sel
             """
+            )
         )
+        == ['fieldA="192.168.0.0/16" OR fieldA="10.0.0.0/8" fieldB="foo" fieldC="bar"']
     )
 
 


### PR DESCRIPTION
1. I improved the regex oring part, making it cleaner, with clear methods and a readable template.
2. I added the ability to handle nested fields like `Event.EventData.fieldX`. Splunk is not allowing dots in regex groups, so I added a field cleaning part. In the case of an `Event.EventData.fieldA`, we are now getting `fieldAMatch` instead of `Event.EventData.fieldAMatch` (which was previously triggering a splunk error in the regex group of [the template](https://github.com/SigmaHQ/pySigma-backend-splunk/blob/2685a3ea67e39287462b55c62ff5fa6ca8c50a7b/sigma/backends/splunk/splunk.py#L46C9-L54C10).
