### PR TITLE
Datamodel improvement

### DIFF
--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -408,12 +408,18 @@ class SplunkBackend(TextQueryBackend):
                 "No data model specified by processing pipeline"
             )
 
-        try:
-            data_set = data_model_set.split(".")[1]
-        except IndexError:
+        if not data_model_set:
             raise SigmaFeatureNotSupportedByBackendError(
                 "No data set specified by processing pipeline"
             )
+
+        if "." in data_model_set:
+            parts = data_model_set.split(".")
+            if len(parts) != 2 or not all(parts):
+                raise SigmaFeatureNotSupportedByBackendError(
+                    "Expected format 'data_model.data_set', but got: {}".format(data_model_set)
+                )
+            data_set = parts[1]
 
         try:
             fields = " ".join(state.processing_state["fields"])


### PR DESCRIPTION
👋 A datamodel can be referenced in two ways:

`from datamodel=Web.Proxy` or `from datamodel=Web where nodename=Web.Proxy`

The previous implementation prevented overriding the datamodel name without dot, making it impossible to use the second format.

The first format doesn't work in some Splunk environments:

![image](https://github.com/user-attachments/assets/6ca8e1d4-fe6b-4d00-8cf1-431e75e7969a)
