### PR TITLE
Support enrichment fields in correlation aggregation queries

### DIFF
--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -2,7 +2,7 @@ import hashlib
 import re
 from sigma.conversion.state import ConversionState
 from sigma.modifiers import SigmaRegularExpression
-from sigma.correlations import SigmaCorrelationRule
+from sigma.correlations import SigmaCorrelationRule, SigmaRuleReference
 from sigma.rule import SigmaRule, SigmaDetection
 from sigma.conversion.base import TextQueryBackend, DeferredQueryExpression
 from sigma.conversion.deferred import DeferredTextQueryExpression
@@ -226,11 +226,20 @@ class SplunkBackend(TextQueryBackend):
     )
     correlation_search_field_normalization_expression_joiner: ClassVar[str] = ""
 
+    # Enrichment fields for correlation aggregations
+    correlation_fields_expression: ClassVar[Dict[str, str]] = {"stats": " {fields}"}
+    correlation_fields_field_expression: ClassVar[Dict[str, str]] = {
+        "stats": "values({field}) as {field}"
+    }
+    correlation_fields_field_expression_joiner: ClassVar[Dict[str, str]] = {
+        "stats": " "
+    }
+
     event_count_aggregation_expression: ClassVar[Dict[str, str]] = {
-        "stats": "| bin _time span={timespan}\n| stats count as event_count by _time{groupby}",
+        "stats": "| bin _time span={timespan}\n| stats count as event_count{fields} by _time{groupby}",
     }
     value_count_aggregation_expression: ClassVar[Dict[str, str]] = {
-        "stats": "| bin _time span={timespan}\n| stats dc({field}) as value_count by _time{groupby}",
+        "stats": "| bin _time span={timespan}\n| stats dc({field}) as value_count{fields} by _time{groupby}",
     }
     temporal_aggregation_expression: ClassVar[Dict[str, str]] = {
         "stats": "| bin _time span={timespan}\n| stats dc(event_type) as event_type_count by _time{groupby}",
@@ -263,6 +272,53 @@ class SplunkBackend(TextQueryBackend):
     extended_correlation_condition_rule_reference_expression: ClassVar[dict[str, str]] = {
         "stats": 'event_types="{ruleid}"'
     }
+
+    def convert_correlation_aggregation_fields_from_template(
+        self,
+        correlation_rule_fields: List[str],
+        referenced_rules: List[SigmaRuleReference],
+        group_by: Optional[List[str]],
+        method: str,
+    ) -> str:
+        """Build the enrichment fields expression for a correlation aggregation.
+
+        This overrides the core implementation so that enrichment fields come ONLY from the
+        correlation rule's own ``fields:`` list. Referenced base-rule fields are deliberately
+        ignored, keeping the change purely additive: a correlation rule without its own
+        ``fields:`` renders byte-identically to the stock backend, regardless of what its
+        referenced rules declare. Fields appearing in ``group_by`` are still excluded, and the
+        empty-string and None-template guards match core behaviour.
+
+        The Sigma correlation rules specification defines ``fields:`` on a correlation rule as
+        the fields to output alongside the aggregation, distinct from the ``fields:`` of the
+        referenced rules. Scoping enrichment to the correlation rule's own list follows that
+        definition and avoids changing existing base-rule (``| table``) output.
+        See https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-correlation-rules-specification.md
+        """
+        if self.correlation_fields_expression is None:
+            return ""
+        all_fields = []
+        # Include ONLY fields declared on the correlation rule itself (ignore referenced rules).
+        for fld in correlation_rule_fields:
+            # Exclude groupby fields and keep only unique fields (remove duplicates)
+            if (group_by is None or fld not in group_by) and fld not in all_fields:
+                all_fields.append(fld)
+        if (
+            len(all_fields) == 0
+            or self.correlation_fields_field_expression is None
+            or self.correlation_fields_field_expression_joiner is None
+        ):
+            return ""
+        return self.correlation_fields_expression[method].format(
+            fields=self.correlation_fields_field_expression_joiner[method].join(
+                (
+                    self.correlation_fields_field_expression[method].format(
+                        field=self.escape_and_quote_field(field)
+                    )
+                    for field in all_fields
+                )
+            )
+        )
 
     def __init__(
         self,

--- a/tests/test_backend_splunk_correlations.py
+++ b/tests/test_backend_splunk_correlations.py
@@ -75,6 +75,185 @@ correlation:
 | search value_count < 10"""
     ]
 
+def test_value_count_correlation_rule_with_fields_stats_query(splunk_backend):
+    """Test value_count correlation WITH fields: enrichment fields should be added to stats."""
+    correlation_rule = SigmaCollection.from_yaml(
+        """
+title: Base rule
+name: base_rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value1
+        fieldB: value2
+    condition: selection
+---
+title: Multiple occurrences with enrichment
+status: test
+correlation:
+    type: value_count
+    rules:
+        - base_rule
+    group-by:
+        - fieldC
+    timespan: 15m
+    condition:
+        lt: 10
+        field: fieldD
+fields:
+    - device_name
+    - source_ip
+    - username
+            """
+    )
+    assert splunk_backend.convert(correlation_rule) == [
+        """fieldA="value1" fieldB="value2"
+
+| bin _time span=15m
+| stats dc(fieldD) as value_count values(device_name) as device_name values(source_ip) as source_ip values(username) as username by _time fieldC
+
+| search value_count < 10"""
+    ]
+
+def test_value_count_correlation_rule_without_fields_unchanged(splunk_backend):
+    """Test value_count correlation WITHOUT fields: output must be byte-identical to v2.1.0 baseline."""
+    correlation_rule = SigmaCollection.from_yaml(
+        """
+title: Base rule
+name: base_rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value1
+        fieldB: value2
+    condition: selection
+---
+title: Multiple occurrences of base event
+status: test
+correlation:
+    type: value_count
+    rules:
+        - base_rule
+    group-by:
+        - fieldC
+    timespan: 15m
+    condition:
+        lt: 10
+        field: fieldD
+            """
+    )
+    # This MUST match the exact output from the existing test_value_count_correlation_rule_stats_query
+    assert splunk_backend.convert(correlation_rule) == [
+        """fieldA="value1" fieldB="value2"
+
+| bin _time span=15m
+| stats dc(fieldD) as value_count by _time fieldC
+
+| search value_count < 10"""
+    ]
+
+def test_value_count_correlation_base_rule_fields_ignored(splunk_backend):
+    """Regression: base rule HAS fields but correlation section has NONE.
+
+    Enrichment must come only from the correlation rule's own fields, so the base rule's fields
+    must NOT leak into the output. Result must be byte-identical to stock (no values() clauses).
+    """
+    correlation_rule = SigmaCollection.from_yaml(
+        """
+title: Base rule
+name: base_rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value1
+        fieldB: value2
+    condition: selection
+fields:
+    - target.displayName
+    - actor.alternateId
+    - client.ipAddress
+    - published
+---
+title: Multiple occurrences of base event
+status: test
+correlation:
+    type: value_count
+    rules:
+        - base_rule
+    group-by:
+        - fieldC
+    timespan: 15m
+    condition:
+        lt: 10
+        field: fieldD
+            """
+    )
+    result = splunk_backend.convert(correlation_rule)
+    assert "values(" not in result[0]
+    assert result == [
+        """fieldA="value1" fieldB="value2"
+
+| bin _time span=15m
+| stats dc(fieldD) as value_count by _time fieldC
+
+| search value_count < 10"""
+    ]
+
+def test_event_count_correlation_rule_with_fields_stats_query(splunk_backend):
+    """Test event_count correlation WITH its own fields: enrichment fields should be added to stats.
+
+    Fields are declared on the CORRELATION section, not the base rule. The base rule's own fields
+    must NOT leak into the enrichment output.
+    """
+    correlation_rule = SigmaCollection.from_yaml(
+        """
+title: Base rule
+name: base_rule
+status: test
+logsource:
+    category: test
+detection:
+    selection:
+        fieldA: value1
+        fieldB: value2
+    condition: selection
+fields:
+    - should_not_appear
+---
+title: Multiple occurrences with enrichment
+status: test
+correlation:
+    type: event_count
+    rules:
+        - base_rule
+    group-by:
+        - fieldC
+        - fieldD
+    timespan: 15m
+    condition:
+        gte: 10
+fields:
+    - fieldE
+    - fieldF
+            """
+    )
+    result = splunk_backend.convert(correlation_rule)
+    assert "should_not_appear" not in result[0]
+    assert result == [
+        """fieldA="value1" fieldB="value2"
+
+| bin _time span=15m
+| stats count as event_count values(fieldE) as fieldE values(fieldF) as fieldF by _time fieldC fieldD
+
+| search event_count >= 10"""
+    ]
+
 def test_temporal_correlation_rule_stats_query(splunk_backend):
     correlation_rule = SigmaCollection.from_yaml(
         """


### PR DESCRIPTION
This adds support for the Sigma `fields:` attribute on correlation rules, so authors can carry additional context columns into the generated `stats` aggregation.

Today a `value_count` or `event_count` correlation renders only the aggregation metric and the group-by keys:

```
| stats dc(user) as value_count by _time device_id
```

Any fields listed on the correlation rule are dropped, so useful investigative context (a display name, source IP, and so on) has to be added by hand after conversion. With this change, fields declared on the correlation rule are emitted as `values()` clauses inside the same `stats` command:

```
| stats dc(user) as value_count values(device_name) as device_name values(src_ip) as src_ip by _time device_id
```

## Implementation

- Adds `correlation_fields_expression`, `correlation_fields_field_expression`, and `correlation_fields_field_expression_joiner` for the `stats` method, using the existing hook points in the core `TextQueryBackend`.
- Adds a `{fields}` slot to the `event_count` and `value_count` aggregation templates.
- Overrides `convert_correlation_aggregation_fields_from_template` so enrichment is drawn only from the correlation rule's own `fields:` list. Fields that appear in `group-by` are excluded, and the None/empty guards match the core implementation.

The [Sigma correlation rules specification](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-correlation-rules-specification.md) defines `fields:` on a correlation rule as the fields to output alongside the aggregation, separate from the `fields:` of the referenced rules. Scoping enrichment to the correlation rule's own list follows that definition.

## Backwards compatibility

The change is additive. A correlation rule with no `fields:` produces byte-identical output to before, so existing rules and their expected queries are unaffected. The one deliberate design choice is that fields declared on referenced base rules are not pulled into the aggregation: only the correlation rule's own `fields:` drive enrichment. This keeps base rules (whose `fields:` normally feed a standalone `| table`) from silently changing correlation output.

## Known limitation

Output columns are named after the field itself (`values(fieldA) as fieldA`), because the Sigma `fields:` list has no alias syntax. For fields whose names include characters that Splunk quotes (for example nested paths like `target{}.displayName`), the resulting column name carries that raw path. The query is valid and returns the expected values; only the column heading is verbose. Aliasing would need a mapping mechanism in the rule schema, which is out of scope here.

## Tests

Adds coverage for `value_count` and `event_count` correlations with enrichment fields, a regression test asserting no change when `fields:` is absent, and a test confirming referenced base-rule fields do not leak into the aggregation. Existing tests are unchanged and all pass.
