### PR TITLE
Add rex extraction for scalar |re modifiers with named capture groups

### DIFF
--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -35,6 +35,23 @@ class SplunkDeferredRegularExpression(DeferredTextQueryExpression):
     default_field = "_raw"
 
 
+class SplunkDeferredRexExpression(DeferredTextQueryExpression):
+    """Deferred field extraction via Splunk ``rex`` command.
+
+    Used for scalar regular expressions that contain named capture groups
+    (``(?P<name>...)``). ``rex`` extracts the named groups into fields, but in
+    contrast to the ``regex`` command it does not filter events, so it is
+    emitted in addition to the matching ``regex`` command.
+    """
+
+    template = 'rex field={field} "{value}"'
+    operators = {
+        True: "=",
+        False: "=",
+    }
+    default_field = "_raw"
+
+
 class SplunkDeferredORRegularExpression(DeferredTextQueryExpression):
     field_counts = {}
     default_field = "_raw"
@@ -294,6 +311,23 @@ class SplunkBackend(TextQueryBackend):
             )  # cannot use \ in f-strings
         return output
 
+    # Matches a Python-style named capture group, e.g. (?P<user>\S+).
+    _named_group_re: ClassVar[Pattern] = re.compile(r"(?<!\\)\(\?P<(\w+)>")
+
+    def _as_splunk_named_group_syntax(self, regex: str) -> Optional[str]:
+        """Convert Python-style named capture groups in ``regex`` to Splunk's PCRE
+        syntax if any are present and not escaped, otherwise return None.
+
+        Sigma regular expressions use Python syntax (``(?P<name>...)``) while the
+        Splunk ``rex`` command uses PCRE syntax (``(?<name>...)``). PCRE accepts both
+        forms, but the Python form is converted for consistency with the group names
+        the backend generates itself. Escaped group parentheses (``\\(?P<``) are left
+        untouched so that literal matches are not rewritten.
+        """
+        if not self._named_group_re.search(regex):
+            return None
+        return self._named_group_re.sub(r"(?<\1>", regex)
+
     def convert_condition_field_eq_val_re(
         self,
         cond: ConditionFieldEqualsValueExpression,
@@ -315,9 +349,24 @@ class SplunkBackend(TextQueryBackend):
             )
             # returning fieldX=true
             return super().convert_condition_field_eq_val_str(cond_true, state)
-        return SplunkDeferredRegularExpression(
-            state, cond.field, super().convert_condition_field_eq_val_re(cond, state)
+
+        regex_value = super().convert_condition_field_eq_val_re(cond, state)
+        deferred_regex = SplunkDeferredRegularExpression(
+            state, cond.field, regex_value
         ).postprocess(None, cond)
+
+        # Scalar regular expressions containing named capture groups are turned
+        # into an additional rex extraction. rex only extracts fields and does
+        # not filter events, hence the regex command above is kept to preserve
+        # the matching semantics. Extraction is omitted for negated conditions.
+        if not cond.parent_condition_chain_contains(ConditionNOT):
+            splunk_regex = self._as_splunk_named_group_syntax(regex_value)
+            if splunk_regex is not None:
+                SplunkDeferredRexExpression(
+                    state, cond.field, splunk_regex
+                ).postprocess(None, cond)
+
+        return deferred_regex
 
     def convert_condition_field_eq_field(
         self,

--- a/tests/test_backend_splunk.py
+++ b/tests/test_backend_splunk.py
@@ -344,6 +344,116 @@ def test_splunk_regex_group_name_keeps_suffix_when_truncated():
     assert field_match.endswith("Match2")
 
 
+def test_splunk_regex_query_with_named_capture_group(splunk_backend: SplunkBackend):
+    """Scalar |re values containing a named capture group are converted to a rex
+    extraction command in addition to the regex matching command."""
+    assert (
+        splunk_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    User|re: '(?P<user>\\S+)'
+                    CommandLine: foo
+                condition: sel
+        """
+            )
+        )
+        == [
+            'CommandLine="foo"'
+            '\n| regex User="(?P<user>\\\\S+)"'
+            '\n| rex field=User "(?<user>\\\\S+)"'
+        ]
+    )
+
+
+def test_splunk_single_regex_query_with_named_capture_group(
+    splunk_backend: SplunkBackend,
+):
+    assert (
+        splunk_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    User|re: '(?P<user>\\S+)'
+                condition: sel
+        """
+            )
+        )
+        == [
+            "*"
+            '\n| regex User="(?P<user>\\\\S+)"'
+            '\n| rex field=User "(?<user>\\\\S+)"'
+        ]
+    )
+
+
+def test_splunk_regex_query_with_multiple_named_capture_groups(
+    splunk_backend: SplunkBackend,
+):
+    assert (
+        splunk_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    User|re: '(?P<user>\\S+)\\.(?P<domain>\\S+)'
+                    CommandLine: foo
+                condition: sel
+        """
+            )
+        )
+        == [
+            'CommandLine="foo"'
+            '\n| regex User="(?P<user>\\\\S+)\\\\.(?P<domain>\\\\S+)"'
+            '\n| rex field=User "(?<user>\\\\S+)\\\\.(?<domain>\\\\S+)"'
+        ]
+    )
+
+
+def test_splunk_regex_query_named_capture_group_not_extracted_when_negated(
+    splunk_backend: SplunkBackend,
+):
+    """Negated regular expressions must keep the regex matching command but must
+    not emit a rex extraction, since the negated match has no usable capture."""
+    assert (
+        splunk_backend.convert(
+            SigmaCollection.from_yaml(
+                """
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    User: bar
+                filter:
+                    User|re: '(?P<user>\\S+)'
+                condition: sel and not filter
+        """
+            )
+        )
+        == ['User="bar"\n| regex User!="(?P<user>\\\\S+)"']
+    )
+
+
 def test_splunk_single_regex_query(splunk_backend: SplunkBackend):
     assert (
         splunk_backend.convert(


### PR DESCRIPTION
Closes #70

## Summary

Extends the regex conversion for **scalar** `|re` modifiers (string values) so that regular expressions containing a **named capture group** (`(?P<name>...)`) are additionally converted to a Splunk `rex` extraction command, while preserving the existing matching semantics of the `regex` command.

Previously, scalar `|re` values were always emitted solely as a `regex` matching command, which cannot extract captured groups into fields. This change appends a `rex field=<field> "(?<name>...)"` command when a Python-style named capture group is present, converting the group to Splunk's PCRE syntax (`(?<name>...)`) for consistency with the group names the backend already generates (e.g. in the OR path).

### Before

```ini
| regex User="(?P<user>\S+)"
```

### After

```ini
| regex User="(?P<user>\S+)"
| rex field=User "(?<user>\S+)"
```

## Design notes

- The `regex` matching command is retained alongside `rex`. Splunk's `rex` command only extracts fields and does **not** filter events; emitting `rex` on its own would silently broaden the result set and regress detection quality. Keeping both commands preserves the exact match semantics while making the captured fields available downstream.
- Group syntax is converted from Python (`(?P<name>...)`) to PCRE (`(?<name>...)`) so the extracted field names align with the conventions used by `SplunkDeferredORRegularExpression`.
- Extraction is intentionally skipped for negated conditions (`not <field>|re: ...`), where a negated match has no usable capture, and for escaped group parentheses so literal matches are not rewritten.
- List-valued `|re` modifiers (the OR path) are left unchanged.

## Changes

- `sigma/backends/splunk/splunk.py`
  - Add `SplunkDeferredRexExpression`, a deferred expression producing `rex field=<field> "<pattern>"`.
  - Detect unescaped Python-style named capture groups in scalar `|re` values and append a `rex` extraction while keeping the existing `regex` matching command.
- `tests/test_backend_splunk.py`
  - Add tests covering a named group alongside other fields, a standalone named group, multiple named groups, and the negated-condition case.

## Testing

`pytest tests` — **129 passed** (125 existing + 4 new), no warnings.