### PR TITLE
Feat/improve data model conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,32 @@ It supports the following output formats:
 * default: plain Splunk queries
 * savedsearches: Splunk savedsearches.conf format.
 
+## Data model (tstats) query settings
+
+The `data_model` output format generates accelerated `tstats` queries against a Splunk data
+model. The following settings let you tune the generated query without changing the Sigma
+rules themselves. They are read from the pipeline processing state (set with a
+`SetStateTransformation` / the `set_state` pipeline item), so detection logic stays separate
+from environment-specific query configuration. Defaults keep the generated query unchanged.
+
+* `summariesonly` (also available as the `summariesonly` backend option, e.g.
+  `-O summariesonly=true` with sigma-cli): controls the `tstats summariesonly=...` flag.
+  Accepts a boolean or a string (`true`/`false`). When both are set, the pipeline
+  processing state takes precedence over the backend option. Default: `false`.
+
+The following are Splunk-specific extensions of the data model output and have no direct
+representation in the Sigma standard:
+
+* `tstats_span`: adds `_time` to the `by` clause and a `span=<value>` bucket, e.g.
+  `tstats_span: 1h`. The value must match `\d+[a-zA-Z]*`.
+* `tstats_aggregations`: a list of additional aggregation functions appended after the
+  default `count`. Each entry is a mapping with `func` (one of the supported Splunk stats
+  functions, e.g. `values`, `sum`, `dc`), `field`, and an optional `as`/`alias`, e.g.
+  `[{func: values, field: Processes.process_name, as: process_names}]`. `count` is always
+  present and cannot be redefined here.
+* `tstats_aggregation`: a raw aggregation string appended verbatim after `count` (advanced
+  use). When set, it takes precedence over `tstats_aggregations`.
+
 This backend is currently maintained by:
 
 * [Thomas Patzke](https://github.com/thomaspatzke/)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ The following are Splunk-specific extensions of the data model output and have n
 representation in the Sigma standard:
 
 * `tstats_span`: adds `_time` to the `by` clause and a `span=<value>` bucket, e.g.
-  `tstats_span: 1h`. The value must match `\d+[a-zA-Z]*`.
+  `tstats_span: 1h`. The value is a number followed by an optional Splunk time unit
+  (`s`, `sec`, `secs`, `second`, `seconds`, `m`, `min`, `mins`, `minute`, `minutes`,
+  `h`, `hr`, `hrs`, `hour`, `hours`, `d`, `day`, `days`, `mon`, `mont`, `months`); a bare
+  number (e.g. `30`) is treated as seconds.
 * `tstats_aggregations`: a list of additional aggregation functions appended after the
   default `count`. Each entry is a mapping with `func` (one of the supported Splunk stats
   functions, e.g. `values`, `sum`, `dc`), `field`, and an optional `as`/`alias`, e.g.

--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -277,7 +277,6 @@ class SplunkBackend(TextQueryBackend):
         "avg", "dc", "distinct_count", "earliest", "estdc", "first", "last",
         "latest", "list", "max", "mean", "median", "min", "mode", "range",
         "stdev", "stdevp", "sum", "sumsq", "values", "var", "varp",
-        "per_day", "per_hour", "per_minute", "per_second",
     }
     _data_model_identifier_re: ClassVar[Pattern] = re.compile(r"^[\w.]+$")
     _data_model_span_re: ClassVar[Pattern] = re.compile(r"^\d+[a-zA-Z]*$")

--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -23,7 +23,7 @@ from sigma.pipelines.splunk.splunk import (
     splunk_dns_cim_mapping,
 )
 import sigma
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Pattern, Tuple, Union
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Pattern, Set, Tuple, Union
 
 
 class SplunkDeferredRegularExpression(DeferredTextQueryExpression):
@@ -272,6 +272,16 @@ class SplunkBackend(TextQueryBackend):
         "stats": 'event_types="{ruleid}"'
     }
 
+    # Splunk stats/tstats functions allowed in the `tstats_aggregations` data model setting.
+    data_model_aggregation_functions: ClassVar[Set[str]] = {
+        "avg", "dc", "distinct_count", "earliest", "estdc", "first", "last",
+        "latest", "list", "max", "mean", "median", "min", "mode", "range",
+        "stdev", "stdevp", "sum", "sumsq", "values", "var", "varp",
+        "per_day", "per_hour", "per_minute", "per_second",
+    }
+    _data_model_identifier_re: ClassVar[Pattern] = re.compile(r"^[\w.]+$")
+    _data_model_span_re: ClassVar[Pattern] = re.compile(r"^\d+[a-zA-Z]*$")
+
     def __init__(
         self,
         processing_pipeline: Optional[
@@ -280,11 +290,13 @@ class SplunkBackend(TextQueryBackend):
         collect_errors: bool = False,
         min_time: str = "-30d",
         max_time: str = "now",
+        summariesonly: bool = False,
         query_settings: Callable[[SigmaRule], Dict[str, str]] = lambda x: {},
         output_settings: Dict = {},
         **kwargs,
     ):
         super().__init__(processing_pipeline, collect_errors, **kwargs)
+        self.summariesonly = summariesonly
         self.query_settings = query_settings
         self.output_settings = {
             "dispatch.earliest_time": min_time,
@@ -557,13 +569,87 @@ class SplunkBackend(TextQueryBackend):
         if has_or_regex_deferred:
             deferred_part += search_marker + where_query
 
-        return f"""| tstats summariesonly=false allow_old_summaries=true fillnull_value="null" count min(_time) as firstTime max(_time) as lastTime from datamodel={data_model_set} where {where_query} by {fields}{deferred_part}
+        summariesonly = self._data_model_summariesonly(state)
+        aggregation = self._data_model_aggregation(state)
+        time_prefix, span_suffix = self._data_model_span(state)
+
+        return f"""| tstats summariesonly={summariesonly} allow_old_summaries=true fillnull_value="null" count min(_time) as firstTime max(_time) as lastTime{aggregation} from datamodel={data_model_set} where {where_query} by {time_prefix}{fields}{span_suffix}{deferred_part}
 | `drop_dm_object_name({data_set})`
 | convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(firstTime)
 | convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(lastTime)
 """.replace(
             "\n", " "
         )
+
+    def _data_model_summariesonly(self, state: ConversionState) -> str:
+        """Resolve tstats `summariesonly` from pipeline state, falling back to the backend option."""
+        value = state.processing_state.get("summariesonly", self.summariesonly)
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in ("true", "t", "yes", "1"):
+                return "true"
+            if normalized in ("false", "f", "no", "0"):
+                return "false"
+            raise SigmaFeatureNotSupportedByBackendError(
+                f"Invalid 'summariesonly' value for tstats data model query: {value!r}"
+            )
+        return self.bool_values[bool(value)]
+
+    def _data_model_aggregation(self, state: ConversionState) -> str:
+        """Render extra tstats aggregation functions from pipeline state, appended to the default count."""
+        raw = state.processing_state.get("tstats_aggregation")
+        if raw is not None:
+            raw = str(raw).strip()
+            return f" {raw}" if raw else ""
+        specs = state.processing_state.get("tstats_aggregations")
+        if not specs:
+            return ""
+        return "".join(
+            f" {self._render_data_model_aggregation(spec)}" for spec in specs
+        )
+
+    def _render_data_model_aggregation(self, spec: Dict[str, str]) -> str:
+        if not isinstance(spec, dict):
+            raise SigmaFeatureNotSupportedByBackendError(
+                f"Each 'tstats_aggregations' entry must be a mapping, got: {spec!r}"
+            )
+        func = str(spec.get("func", "")).strip().lower()
+        if func not in self.data_model_aggregation_functions:
+            raise SigmaFeatureNotSupportedByBackendError(
+                f"Unsupported tstats aggregation function: {spec.get('func')!r}"
+            )
+        field = spec.get("field")
+        if not field:
+            raise SigmaFeatureNotSupportedByBackendError(
+                f"tstats aggregation function '{func}' requires a 'field'"
+            )
+        field = str(field).strip()
+        if not self._data_model_identifier_re.match(field):
+            raise SigmaFeatureNotSupportedByBackendError(
+                f"Invalid field name in 'tstats_aggregations': {field!r}"
+            )
+        token = f"{func}({field})"
+        alias = spec.get("as") or spec.get("alias")
+        if alias:
+            alias = str(alias).strip()
+            if not self._data_model_identifier_re.match(alias):
+                raise SigmaFeatureNotSupportedByBackendError(
+                    f"Invalid alias in 'tstats_aggregations': {alias!r}"
+                )
+            token += f" as {alias}"
+        return token
+
+    def _data_model_span(self, state: ConversionState) -> Tuple[str, str]:
+        """Return the `_time`/`span=` fragments for tstats time bucketing from pipeline state."""
+        span = state.processing_state.get("tstats_span")
+        if span is None:
+            return "", ""
+        span = str(span).strip()
+        if not self._data_model_span_re.match(span):
+            raise SigmaFeatureNotSupportedByBackendError(
+                f"Invalid 'tstats_span' value for tstats data model query: {span!r}"
+            )
+        return "_time ", f" span={span}"
 
     def finalize_output_data_model(self, queries: List[str]) -> List[str]:
         return queries

--- a/sigma/backends/splunk/splunk.py
+++ b/sigma/backends/splunk/splunk.py
@@ -279,7 +279,9 @@ class SplunkBackend(TextQueryBackend):
         "stdev", "stdevp", "sum", "sumsq", "values", "var", "varp",
     }
     _data_model_identifier_re: ClassVar[Pattern] = re.compile(r"^[\w.]+$")
-    _data_model_span_re: ClassVar[Pattern] = re.compile(r"^\d+[a-zA-Z]*$")
+    _data_model_span_re: ClassVar[Pattern] = re.compile(
+        r"^\d+(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days|mon|mont|months)?$"
+    )
 
     def __init__(
         self,

--- a/tests/test_backend_splunk.py
+++ b/tests/test_backend_splunk.py
@@ -954,3 +954,314 @@ detection:
         SigmaFeatureNotSupportedByBackendError, match="No data model specified"
     ):
         splunk_backend.convert(SigmaCollection.from_yaml(rule), "data_model")
+
+
+# --- Configurable data model (tstats) query settings -------------------------
+
+
+def test_splunk_data_model_summariesonly_backend_option():
+    splunk_backend = SplunkBackend(
+        processing_pipeline=splunk_cim_data_model(), summariesonly=True
+    )
+    rule = """
+title: Test
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: test
+    condition: sel
+    """
+    assert splunk_backend.convert(SigmaCollection.from_yaml(rule), "data_model") == [
+        """| tstats summariesonly=true allow_old_summaries=true fillnull_value="null" count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes where
+Processes.process="test" by Processes.process Processes.dest Processes.process_current_directory Processes.process_path Processes.process_integrity_level Processes.original_file_name Processes.parent_process
+Processes.parent_process_path Processes.parent_process_guid Processes.parent_process_id Processes.process_guid Processes.process_id Processes.user
+| `drop_dm_object_name(Processes)`
+| convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(firstTime)
+| convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(lastTime)
+""".replace(
+            "\n", " "
+        )
+    ]
+
+
+def test_splunk_data_model_summariesonly_pipeline_state_overrides_option():
+    # Pipeline processing state takes precedence over the backend option.
+    pipeline = splunk_cim_data_model() + ProcessingPipeline.from_yaml(
+        """
+        name: Test
+        priority: 100
+        transformations:
+            - id: set_summariesonly
+              type: set_state
+              key: summariesonly
+              val: false
+        """
+    )
+    splunk_backend = SplunkBackend(processing_pipeline=pipeline, summariesonly=True)
+    rule = """
+title: Test
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: test
+    condition: sel
+    """
+    assert splunk_backend.convert(SigmaCollection.from_yaml(rule), "data_model") == [
+        """| tstats summariesonly=false allow_old_summaries=true fillnull_value="null" count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes where
+Processes.process="test" by Processes.process Processes.dest Processes.process_current_directory Processes.process_path Processes.process_integrity_level Processes.original_file_name Processes.parent_process
+Processes.parent_process_path Processes.parent_process_guid Processes.parent_process_id Processes.process_guid Processes.process_id Processes.user
+| `drop_dm_object_name(Processes)`
+| convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(firstTime)
+| convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(lastTime)
+""".replace(
+            "\n", " "
+        )
+    ]
+
+
+def test_splunk_data_model_summariesonly_invalid_string_raises():
+    pipeline = splunk_cim_data_model() + ProcessingPipeline.from_yaml(
+        """
+        name: Test
+        priority: 100
+        transformations:
+            - id: set_summariesonly
+              type: set_state
+              key: summariesonly
+              val: maybe
+        """
+    )
+    splunk_backend = SplunkBackend(processing_pipeline=pipeline)
+    rule = """
+title: Test
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: test
+    condition: sel
+    """
+    with pytest.raises(
+        SigmaFeatureNotSupportedByBackendError, match="Invalid 'summariesonly'"
+    ):
+        splunk_backend.convert(SigmaCollection.from_yaml(rule), "data_model")
+
+
+def test_splunk_data_model_tstats_aggregations():
+    pipeline = splunk_cim_data_model() + ProcessingPipeline.from_yaml(
+        """
+        name: Test
+        priority: 100
+        transformations:
+            - id: set_aggregations
+              type: set_state
+              key: tstats_aggregations
+              val:
+                - func: values
+                  field: Processes.process_name
+                  as: process_names
+                - func: sum
+                  field: Processes.count
+        """
+    )
+    splunk_backend = SplunkBackend(processing_pipeline=pipeline)
+    rule = """
+title: Test
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: test
+    condition: sel
+    """
+    assert splunk_backend.convert(SigmaCollection.from_yaml(rule), "data_model") == [
+        """| tstats summariesonly=false allow_old_summaries=true fillnull_value="null" count min(_time) as firstTime max(_time) as lastTime values(Processes.process_name) as process_names sum(Processes.count) from datamodel=Endpoint.Processes where
+Processes.process="test" by Processes.process Processes.dest Processes.process_current_directory Processes.process_path Processes.process_integrity_level Processes.original_file_name Processes.parent_process
+Processes.parent_process_path Processes.parent_process_guid Processes.parent_process_id Processes.process_guid Processes.process_id Processes.user
+| `drop_dm_object_name(Processes)`
+| convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(firstTime)
+| convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(lastTime)
+""".replace(
+            "\n", " "
+        )
+    ]
+
+
+def test_splunk_data_model_tstats_aggregation_raw_string():
+    pipeline = splunk_cim_data_model() + ProcessingPipeline.from_yaml(
+        """
+        name: Test
+        priority: 100
+        transformations:
+            - id: set_aggregation
+              type: set_state
+              key: tstats_aggregation
+              val: values(Processes.user) as users
+        """
+    )
+    splunk_backend = SplunkBackend(processing_pipeline=pipeline)
+    rule = """
+title: Test
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: test
+    condition: sel
+    """
+    assert splunk_backend.convert(SigmaCollection.from_yaml(rule), "data_model") == [
+        """| tstats summariesonly=false allow_old_summaries=true fillnull_value="null" count min(_time) as firstTime max(_time) as lastTime values(Processes.user) as users from datamodel=Endpoint.Processes where
+Processes.process="test" by Processes.process Processes.dest Processes.process_current_directory Processes.process_path Processes.process_integrity_level Processes.original_file_name Processes.parent_process
+Processes.parent_process_path Processes.parent_process_guid Processes.parent_process_id Processes.process_guid Processes.process_id Processes.user
+| `drop_dm_object_name(Processes)`
+| convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(firstTime)
+| convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(lastTime)
+""".replace(
+            "\n", " "
+        )
+    ]
+
+
+def test_splunk_data_model_tstats_aggregation_invalid_function_raises():
+    pipeline = splunk_cim_data_model() + ProcessingPipeline.from_yaml(
+        """
+        name: Test
+        priority: 100
+        transformations:
+            - id: set_aggregations
+              type: set_state
+              key: tstats_aggregations
+              val:
+                - func: eval
+                  field: Processes.user
+        """
+    )
+    splunk_backend = SplunkBackend(processing_pipeline=pipeline)
+    rule = """
+title: Test
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: test
+    condition: sel
+    """
+    with pytest.raises(
+        SigmaFeatureNotSupportedByBackendError,
+        match="Unsupported tstats aggregation function",
+    ):
+        splunk_backend.convert(SigmaCollection.from_yaml(rule), "data_model")
+
+
+def test_splunk_data_model_tstats_aggregation_invalid_field_raises():
+    pipeline = splunk_cim_data_model() + ProcessingPipeline.from_yaml(
+        """
+        name: Test
+        priority: 100
+        transformations:
+            - id: set_aggregations
+              type: set_state
+              key: tstats_aggregations
+              val:
+                - func: values
+                  field: "Processes.user | delete"
+        """
+    )
+    splunk_backend = SplunkBackend(processing_pipeline=pipeline)
+    rule = """
+title: Test
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: test
+    condition: sel
+    """
+    with pytest.raises(
+        SigmaFeatureNotSupportedByBackendError, match="Invalid field name"
+    ):
+        splunk_backend.convert(SigmaCollection.from_yaml(rule), "data_model")
+
+
+def test_splunk_data_model_tstats_span():
+    pipeline = splunk_cim_data_model() + ProcessingPipeline.from_yaml(
+        """
+        name: Test
+        priority: 100
+        transformations:
+            - id: set_span
+              type: set_state
+              key: tstats_span
+              val: 1h
+        """
+    )
+    splunk_backend = SplunkBackend(processing_pipeline=pipeline)
+    rule = """
+title: Test
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: test
+    condition: sel
+    """
+    assert splunk_backend.convert(SigmaCollection.from_yaml(rule), "data_model") == [
+        """| tstats summariesonly=false allow_old_summaries=true fillnull_value="null" count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes where
+Processes.process="test" by _time Processes.process Processes.dest Processes.process_current_directory Processes.process_path Processes.process_integrity_level Processes.original_file_name Processes.parent_process
+Processes.parent_process_path Processes.parent_process_guid Processes.parent_process_id Processes.process_guid Processes.process_id Processes.user span=1h
+| `drop_dm_object_name(Processes)`
+| convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(firstTime)
+| convert timeformat="%Y-%m-%dT%H:%M:%S" ctime(lastTime)
+""".replace(
+            "\n", " "
+        )
+    ]
+
+
+def test_splunk_data_model_tstats_span_invalid_raises():
+    pipeline = splunk_cim_data_model() + ProcessingPipeline.from_yaml(
+        """
+        name: Test
+        priority: 100
+        transformations:
+            - id: set_span
+              type: set_state
+              key: tstats_span
+              val: "1h | delete"
+        """
+    )
+    splunk_backend = SplunkBackend(processing_pipeline=pipeline)
+    rule = """
+title: Test
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: test
+    condition: sel
+    """
+    with pytest.raises(
+        SigmaFeatureNotSupportedByBackendError, match="Invalid 'tstats_span'"
+    ):
+        splunk_backend.convert(SigmaCollection.from_yaml(rule), "data_model")
+


### PR DESCRIPTION
 # Splunk backend: configurable data model (`tstats`) query settings

Branch: `feat/improve-data-model-conversion`

## Problem

The `data_model` output format emitted a **fixed** `tstats` query. Everything after
`count min(_time)... max(_time)...` was hardcoded, so the accelerated query could not be
adapted to an environment without patching the backend or post-processing its output:

- `summariesonly=false` was **hardcoded** — no way to force `summariesonly=true`
  (accelerated-data-only) per environment.
- **Only `count`** was produced — no way to add `values(...)`, `dc(...)`, `sum(...)`, etc.
- **No time bucketing** — no way to group over `_time` with a `span=`.
- Detection logic (Sigma rules) and environment-specific query tuning were entangled.

## Fix

Added opt-in settings read from the **pipeline processing state** (`set_state`), plus a
`summariesonly` backend option. Defaults keep the generated query **byte-for-byte
identical**, so existing behaviour is unchanged. All inputs are validated (allow-listed
functions, regex-checked identifiers/spans) to prevent SPL injection.

| Setting | Where | Purpose |
|---|---|---|
| `summariesonly` | backend option **or** `set_state` | toggles `tstats summariesonly=...` |
| `tstats_span` | `set_state` | adds `_time` to `by` + `span=<value>` |
| `tstats_aggregations` | `set_state` | structured extra aggregation functions after `count` |
| `tstats_aggregation` | `set_state` | raw aggregation string (advanced; wins over the list) |

## Examples

> `by`-field lists abbreviated with `...` for readability.

### Default (unchanged)

```spl
| tstats summariesonly=false allow_old_summaries=true fillnull_value="null" count min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes where Processes.process="test" by Processes.process ... | `drop_dm_object_name(Processes)` | ...
```

### `summariesonly`

Backend option (also `-O summariesonly=true` with sigma-cli):

```python
SplunkBackend(summariesonly=True)
```

Or via pipeline (pipeline state takes precedence over the backend option):

```yaml
transformations:
  - id: set_summariesonly
    type: set_state
    key: summariesonly
    val: true
```

Result:

```spl
| tstats summariesonly=true allow_old_summaries=true ...
```

### `tstats_aggregations` (structured, appended after `count`)

```yaml
transformations:
  - id: set_aggregations
    type: set_state
    key: tstats_aggregations
    val:
      - func: values
        field: Processes.process_name
        as: process_names
      - func: sum
        field: Processes.count      # `as`/`alias` optional
```

Result:

```spl
| tstats ... count min(_time) as firstTime max(_time) as lastTime values(Processes.process_name) as process_names sum(Processes.count) from datamodel=Endpoint.Processes where ...
```

### `tstats_aggregation` (raw string, advanced — overrides the structured list)

```yaml
  - id: set_aggregation
    type: set_state
    key: tstats_aggregation
    val: values(Processes.user) as users
```

Result:

```spl
| tstats ... max(_time) as lastTime values(Processes.user) as users from datamodel=Endpoint.Processes where ...
```

### `tstats_span` (time bucketing)

```yaml
  - id: set_span
    type: set_state
    key: tstats_span
    val: 1h
```

Result (`_time` added to `by`, `span=` appended):

```spl
| tstats ... from datamodel=Endpoint.Processes where Processes.process="test" by _time Processes.process ... span=1h | `drop_dm_object_name(Processes)` | ...
```

## Validation & safety

- `summariesonly`: accepts a bool or a string (`true`/`false`/`yes`/`no`/`1`/`0`);
  anything else raises `SigmaFeatureNotSupportedByBackendError`.
- `tstats_aggregations`: `func` must be in an allow-list of Splunk stats functions
  (`avg`, `dc`, `sum`, `values`, `min`, `max`, `latest`, `per_hour`, ...); `count` is
  intentionally excluded (always present and cannot be redefined); `field` and alias
  must match `^[\w.]+$`; a missing `field` raises.
- `tstats_span`: must match `^\d+(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days|mon|mont|months)?$`.

Closes #75

@thomaspatzke not sure if this is a solution you like, but I give it a try^^